### PR TITLE
feat: Refactor factories and services to include GqlUpdate DTOs 

### DIFF
--- a/src/_shared/adapter/factory/affectation.factory.ts
+++ b/src/_shared/adapter/factory/affectation.factory.ts
@@ -4,6 +4,7 @@ import { StaffFactory } from './user.factory';
 import { Staff } from 'domain/model/staff.model';
 import { DossierStep } from 'domain/model/dossier-step.model';
 import { ITask } from 'domain/model/task.model';
+import { TaskFactory } from './task.factory';
 
 export class AffectationFactory {
   static create(data: ICreateAffectationDTO, dossier: DossierStep, task: ITask, staff: Staff): Affectation {
@@ -20,13 +21,15 @@ export class AffectationFactory {
   }
 
   static getAffectation(affectation: Affectation): OAffectation {
+    if (!affectation) return undefined as unknown as OAffectation;
    return {
       id: affectation.id,
       report: affectation.report,
       closedAt: affectation.closedAt,
       dossierStep: affectation.dossierStep,
       staff: StaffFactory.getUser(affectation.staff) as Staff,
-      task: affectation.task,
+      task: TaskFactory.getTask(affectation.task) as ITask,
+      user: StaffFactory.getUser(affectation.user!) as Staff,
       createdAt: affectation.createdAt,
       updatedAt: affectation.updatedAt,
     };

--- a/src/_shared/adapter/factory/comment.factory.ts
+++ b/src/_shared/adapter/factory/comment.factory.ts
@@ -16,6 +16,8 @@ export class CommentFactory {
   }
 
   static getComment(comment: IComment): OComment {
+        if (!comment) return undefined as unknown as OComment;
+    
     return {
       id: comment.id,
       content: comment.content,

--- a/src/_shared/adapter/factory/dossier-step.factory.ts
+++ b/src/_shared/adapter/factory/dossier-step.factory.ts
@@ -16,6 +16,7 @@ export class DossierStepFactory {
   }
 
   static getDossierStep(dossierStep: DossierStep): ODossierStep {
+    if (!dossierStep) return undefined as unknown as ODossierStep;
     return {
       id: dossierStep.id,
       startDate: dossierStep.startDate,

--- a/src/_shared/adapter/factory/dossier.factory.ts
+++ b/src/_shared/adapter/factory/dossier.factory.ts
@@ -20,6 +20,7 @@ export class DossierFactory {
   }
 
   static getDossier(dossier: Dossier): ODossier {
+    if (!dossier) return undefined as unknown as ODossier;
     return {
       id: dossier.id,
       name: dossier.name,

--- a/src/_shared/adapter/factory/step.factory.ts
+++ b/src/_shared/adapter/factory/step.factory.ts
@@ -15,6 +15,7 @@ export class StepFactory {
   }
 
   static getStep(step: Step): OStep {
+    if (!step) return undefined as unknown as OStep;
     return {
       id: step.id,
       name: step.name,

--- a/src/_shared/adapter/factory/task.factory.ts
+++ b/src/_shared/adapter/factory/task.factory.ts
@@ -13,6 +13,8 @@ export class TaskFactory {
   }
 
   static getTask(task: ITask): OTask {
+    if (!task) return undefined as unknown as OTask;
+    
     return {
         id: task.id,
         name: task.name,

--- a/src/affectation/affectation.controller.ts
+++ b/src/affectation/affectation.controller.ts
@@ -4,8 +4,9 @@ import { AffectationService } from './affectation.service';
 import { GetUser } from 'adapter/decorator';
 import { StaffGuard } from 'adapter/guard/auth.guard';
 import { Staff } from 'domain/model/staff.model';
-import { CreateAffectationDTO, UpdateAffectationDTO } from './affectation.input.dto';
+import { CreateAffectationDTO, GqlUpdateAffectationDTO, UpdateAffectationDTO } from './affectation.input.dto';
 import { IAffectationService } from './affectation.service.interface';
+import { AffectationFactory } from 'adapter/factory/affectation.factory';
 
 @UseGuards(StaffGuard)
 @ApiBearerAuth()
@@ -18,28 +19,29 @@ export class AffectationController {
   @ApiOperation({ summary: 'Créer une affectation' })
   @ApiResponse({ status: 201, description: 'Affectation créée.' })
   async create(@GetUser() user: Staff, @Body() dto: CreateAffectationDTO) {
-    return this.affectationService.add(user, dto);
+    return await this.affectationService.add(user, dto);
   }
 
   @Get(':id')
   @ApiOperation({ summary: 'Récupérer une affectation par id' })
   @ApiResponse({ status: 200, description: 'Affectation trouvée.' })
   async findOne(@Param('id') id: string) {
-    return this.affectationService.fetchOne(id);
+    return AffectationFactory.getAffectation(await this.affectationService.fetchOne(id));
   }
 
   @Get()
   @ApiOperation({ summary: 'Lister toutes les affectations' })
   @ApiResponse({ status: 200, description: 'Liste des affectations.' })
   async findAll() {
-    return this.affectationService.fetchAll();
+    const list = await this.affectationService.fetchAll();
+    return list.map((affectation) => AffectationFactory.getAffectation(affectation));
   }
 
-  @Patch(':id')
+  @Patch()
   @ApiOperation({ summary: 'Modifier une affectation' })
   @ApiResponse({ status: 200, description: 'Affectation modifiée.' })
-  async update(@Body() dto: UpdateAffectationDTO) {
-    return this.affectationService.edit(dto);
+  async update(@GetUser() user: Staff, @Body() dto: UpdateAffectationDTO) {
+    return AffectationFactory.getAffectation(await this.affectationService.edit(user, dto));
   }
 
   @Delete(':id')

--- a/src/affectation/affectation.input.dto.ts
+++ b/src/affectation/affectation.input.dto.ts
@@ -1,5 +1,5 @@
-import { InputType, Field, ID, PartialType } from '@nestjs/graphql';
-import { ApiProperty } from '@nestjs/swagger';
+import { InputType, Field, ID, PartialType as GqlPartialType } from '@nestjs/graphql';
+import { ApiProperty, PartialType } from '@nestjs/swagger';
 import { IsDateString, IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
 import { ICreateAffectationDTO, IUpdateAffectationDTO } from './affectation.service.interface';
 
@@ -19,9 +19,9 @@ export class CreateAffectationDTO implements ICreateAffectationDTO {
   closedAt?: Date;
 
   @ApiProperty()
-  @Field(() => ID)
+  @Field(() => ID, { description: 'Utiliser DossierStep ID' })
   @IsUUID()
-  dossierId: string;
+  dossierStepId: string;
 
   @ApiProperty()
   @Field(() => ID)
@@ -35,8 +35,14 @@ export class CreateAffectationDTO implements ICreateAffectationDTO {
   taskId?: string;
 }
 
-@InputType()
 export class UpdateAffectationDTO extends PartialType(CreateAffectationDTO) implements IUpdateAffectationDTO {
+  @ApiProperty()
+  @Field(() => ID)
+  @IsUUID()
+  id: string;
+}
+@InputType()
+export class GqlUpdateAffectationDTO extends GqlPartialType(CreateAffectationDTO) implements IUpdateAffectationDTO {
   @ApiProperty()
   @Field(() => ID)
   @IsUUID()

--- a/src/affectation/affectation.resolver.ts
+++ b/src/affectation/affectation.resolver.ts
@@ -6,7 +6,7 @@ import { IAffectationService } from './affectation.service.interface';
 import { GqlAuthGuard } from 'adapter/guard/auth.guard';
 import { GetUser } from 'adapter/decorator';
 import { Staff } from 'domain/model/staff.model';
-import { CreateAffectationDTO, UpdateAffectationDTO } from './affectation.input.dto';
+import { CreateAffectationDTO, GqlUpdateAffectationDTO } from './affectation.input.dto';
 import { AffectationEntity } from 'framework/schema/affectation.entity';
 
 @ApiTags('Dossier Affectations')
@@ -27,13 +27,13 @@ export class AffectationResolver {
   }
 
   @Mutation(() => AffectationEntity)
-  async createAffectation(@GetUser() user: Staff, @Args('data') data: CreateAffectationDTO): Promise<Affectation> {
+  async createAffectation(@GetUser() user: Staff, @Args('data') data: CreateAffectationDTO): Promise<boolean> {
     return this.affectationService.add(user, data);
   }
 
   @Mutation(() => AffectationEntity)
-  async updateAffectation(@Args('data') data: UpdateAffectationDTO): Promise<Affectation> {
-    return this.affectationService.edit(data);
+  async updateAffectation(@GetUser() user: Staff, @Args('data') data: GqlUpdateAffectationDTO): Promise<Affectation> {
+    return this.affectationService.edit(user, data);
   }
 
   @Mutation(() => Boolean)

--- a/src/affectation/affectation.service.interface.ts
+++ b/src/affectation/affectation.service.interface.ts
@@ -4,7 +4,7 @@ import { Staff } from 'domain/model/staff.model';
 export interface ICreateAffectationDTO {
   report: string;
   closedAt?: Date;
-  dossierId: string;
+  dossierStepId: string;
   staffId: string;
   taskId?: string;
   
@@ -16,9 +16,9 @@ export interface IUpdateAffectationDTO extends Partial<ICreateAffectationDTO> {
 }
 
 export abstract class IAffectationService {
-  abstract add(user: Staff, data: ICreateAffectationDTO): Promise<Affectation>;
+  abstract add(user: Staff, data: ICreateAffectationDTO): Promise<boolean>;
   abstract fetchOne(id: string): Promise<Affectation>;
   abstract fetchAll(): Promise<Affectation[]>;
-  abstract edit(data: IUpdateAffectationDTO): Promise<Affectation>;
+  abstract edit(user: Staff, data: IUpdateAffectationDTO): Promise<Affectation>;
   abstract remove(id: string): Promise<boolean>;
 }

--- a/src/affectation/affectation.service.ts
+++ b/src/affectation/affectation.service.ts
@@ -14,33 +14,57 @@ import { IDBRepository } from 'app/abstract/db.abstract';
 import { AffectationFactory } from 'adapter/factory/affectation.factory';
 import { ITask } from 'domain/model/task.model';
 import { Staff } from 'domain/model/staff.model';
+import { DataHelper } from 'adapter/helper/data.helper';
+import { StepStatusEnum } from 'app/enum';
 
 @Injectable()
 export class AffectationService implements IAffectationService {
   private readonly logger = new Logger();
   constructor(private dbRepository: IDBRepository) {}
 
-  async add(user: Staff, data: ICreateAffectationDTO): Promise<Affectation> {
+  async add(user: Staff, data: ICreateAffectationDTO): Promise<boolean> {
     try {
       data.user = user;
       // Vérifier l'existence des dépendances
-      const dossier = await this.dbRepository.dossierSteps.findOneByID(
-        data.dossierId,
-      );
+      const dossier = await this.dbRepository.dossierSteps.findOne({
+        where: { id: data.dossierStepId },
+        relations: { dossier: true, step: true },
+      });
       if (!dossier) throw new NotFoundException('Dossier not found');
       const staff = await this.dbRepository.users.findOneByID(data.staffId);
       if (!staff) throw new NotFoundException('Staff not found');
       let task = undefined as unknown as ITask;
+      const affectations: Affectation[] = [];
       if (data.taskId) {
         task = await this.dbRepository.tasks.findOneByID(data.taskId);
         if (!task) throw new NotFoundException('Task not found');
+
+        affectations.push(
+          AffectationFactory.create(data, dossier, task, staff),
+        );
+      } else {
+        if (dossier.step) {
+          const tasks = await this.dbRepository.tasks.find({
+            where: { step: { id: dossier.step.id } },
+          });
+          if (tasks && DataHelper.isNotEmptyArray(tasks)) {
+            tasks.map((task) => {
+              affectations.push(
+                AffectationFactory.create(data, dossier, task, staff),
+              );
+            });
+          } else {
+            throw new NotFoundException('Task not found');
+          }
+
+        }
       }
       // Vérifier l'unicité de l'affectation
       const existing = await this.dbRepository.affectations.findOne({
         where: {
-          dossierStep: { id: data.dossierId },
+          dossierStep: { id: data.dossierStepId },
           staff: { id: data.staffId },
-          task: { id: data.taskId },
+          task: data.taskId ? { id: data.taskId } : undefined,
         },
       });
       if (existing) {
@@ -48,9 +72,10 @@ export class AffectationService implements IAffectationService {
           'Affectation with the same staff, dossier, and task already exists',
         );
       }
-      return await this.dbRepository.affectations.create(
-        AffectationFactory.create(data, dossier, task, staff),
-      );
+      return await this.dbRepository.affectations
+        .createMany(affectations)
+        .then(() => true)
+        .catch(() => false);
     } catch (error) {
       this.logger.error(error, 'ERROR::AffectationService.add');
       throw error;
@@ -58,20 +83,31 @@ export class AffectationService implements IAffectationService {
   }
 
   async fetchOne(id: string): Promise<Affectation> {
-    const affectation = await this.dbRepository.affectations.findOneByID(id);
+    const affectation = await this.dbRepository.affectations.findOne({
+      relations: { dossierStep: true, task: true, staff: true, user: true },
+      where: { id },
+    });
     if (!affectation) throw new NotFoundException('Affectation not found');
     return affectation;
   }
 
   async fetchAll(): Promise<Affectation[]> {
-    return this.dbRepository.affectations.find();
+    return this.dbRepository.affectations.find({
+      order: { createdAt: 'DESC' },
+    });
   }
 
-  async edit(data: IUpdateAffectationDTO): Promise<Affectation> {
-    const affectation = await this.dbRepository.affectations.findOneByID(
-      data.id,
-    );
+  async edit(user: Staff, data: IUpdateAffectationDTO): Promise<Affectation> {
+    const affectation = await this.dbRepository.affectations.findOne({
+      relations: { dossierStep: true, staff: true, user: true },
+      where: {id: data.id},
+    });
     if (!affectation) throw new NotFoundException('Affectation not found');
+    const dossier = affectation.dossierStep;
+    if (dossier && dossier.status === StepStatusEnum.PENDING) {
+      dossier.status = StepStatusEnum.IN_PROGRESS;
+      await this.dbRepository.dossierSteps.update(dossier);
+    }
     const updated = { ...affectation, ...data };
     return this.dbRepository.affectations.update(updated);
   }

--- a/src/comment/comment.controller.ts
+++ b/src/comment/comment.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Post, Body, Param, Patch, Delete, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { StaffGuard } from 'adapter/guard/auth.guard';
-import { CreateCommentDTO, UpdateCommentDTO } from './comment.input.dto';
+import { CreateCommentDTO, GqlUpdateCommentDTO, UpdateCommentDTO } from './comment.input.dto';
 import { ICommentService } from './comment.service.interface';
 
 @UseGuards(StaffGuard)
@@ -32,7 +32,7 @@ export class CommentController {
     return this.commentService.fetchAll();
   }
 
-  @Patch(':id')
+  @Patch()
   @ApiOperation({ summary: 'Modifier un commentaire' })
   @ApiResponse({ status: 200, description: 'Commentaire modifié.' })
   async update(@Body() dto: UpdateCommentDTO) {

--- a/src/comment/comment.input.dto.ts
+++ b/src/comment/comment.input.dto.ts
@@ -1,5 +1,5 @@
-import { InputType, Field, ID, PartialType } from '@nestjs/graphql';
-import { ApiProperty } from '@nestjs/swagger';
+import { InputType, Field, ID, PartialType as GqlPartialType } from '@nestjs/graphql';
+import { ApiProperty, PartialType } from '@nestjs/swagger';
 import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
 import { ICreateCommentDTO, IUpdateCommentDTO } from './comment.service.interface';
 
@@ -22,8 +22,14 @@ export class CreateCommentDTO implements ICreateCommentDTO {
   staffId: string;
 }
 
-@InputType()
 export class UpdateCommentDTO extends PartialType(CreateCommentDTO) implements IUpdateCommentDTO {
+  @ApiProperty()
+  @Field(() => ID)
+  @IsUUID()
+  id: string;
+}
+@InputType()
+export class GqlUpdateCommentDTO extends GqlPartialType(CreateCommentDTO) implements IUpdateCommentDTO {
   @ApiProperty()
   @Field(() => ID)
   @IsUUID()

--- a/src/comment/comment.resolver.ts
+++ b/src/comment/comment.resolver.ts
@@ -3,7 +3,7 @@ import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { IComment } from 'domain/model/comment.model';
 import { GqlAuthGuard } from 'adapter/guard/auth.guard';
-import { CreateCommentDTO, UpdateCommentDTO } from './comment.input.dto';
+import { CreateCommentDTO, GqlUpdateCommentDTO } from './comment.input.dto';
 import { ICommentService } from './comment.service.interface';
 import { CommentEntity } from 'framework/schema/comment.entity';
 
@@ -30,7 +30,7 @@ export class CommentResolver {
   }
 
   @Mutation(() => CommentEntity)
-  async updateComment(@Args('data') data: UpdateCommentDTO): Promise<IComment> {
+  async updateComment(@Args('data') data: GqlUpdateCommentDTO): Promise<IComment> {
     return this.commentService.edit(data);
   }
 

--- a/src/comment/comment.service.ts
+++ b/src/comment/comment.service.ts
@@ -30,7 +30,7 @@ export class CommentService implements ICommentService {
 
   async fetchAll(): Promise<IComment[]> {
     try {
-      return await this.dbRepository.comments.find();
+      return await this.dbRepository.comments.find({order: {createdAt: 'DESC'}});
     } catch (error) {
       this.logger.error(error, 'ERROR::CommentService.fetchAll');
       throw error;

--- a/src/domain/domain.controller.ts
+++ b/src/domain/domain.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Post, Body, Param, Patch, Delete, UseGuards } from '@n
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { IDomainService } from './domain.service.interface';
 import { StaffGuard } from 'adapter/guard/auth.guard';
-import { CreateDomainDTO, UpdateDomainDTO } from './domain.input.dto';
+import { CreateDomainDTO, GqlUpdateDomainDTO, UpdateDomainDTO } from './domain.input.dto';
 import { IDsBodyDTO } from 'adapter/param.dto';
 
 @UseGuards(StaffGuard)

--- a/src/domain/domain.input.dto.ts
+++ b/src/domain/domain.input.dto.ts
@@ -1,5 +1,5 @@
-import { InputType, Field, PartialType } from '@nestjs/graphql';
-import { ApiProperty } from '@nestjs/swagger';
+import { InputType, Field, ID, PartialType as GqlPartialType } from '@nestjs/graphql';
+import { ApiProperty, PartialType } from '@nestjs/swagger';
 import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
 
 @InputType()
@@ -17,8 +17,16 @@ export class CreateDomainDTO {
   description?: string;
 }
 
-@InputType()
 export class UpdateDomainDTO extends PartialType(CreateDomainDTO) {
+  @ApiProperty({ example: 'uuid-du-domaine', description: 'ID du domaine' })
+  @Field({ nullable: true })
+  @IsString()
+  @IsUUID()
+  id: string;
+}
+
+@InputType()
+export class GqlUpdateDomainDTO extends GqlPartialType(CreateDomainDTO) {
   @ApiProperty({ example: 'uuid-du-domaine', description: 'ID du domaine' })
   @Field({ nullable: true })
   @IsString()

--- a/src/domain/domain.resolver.ts
+++ b/src/domain/domain.resolver.ts
@@ -1,6 +1,6 @@
 import { Resolver, Query, Mutation, Args, ID } from '@nestjs/graphql';
 import { UseGuards } from '@nestjs/common';
-import { CreateDomainDTO, UpdateDomainDTO } from './domain.input.dto';
+import { CreateDomainDTO, GqlUpdateDomainDTO } from './domain.input.dto';
 import { DomainEntity } from 'framework/schema/domain.entity';
 import { ODomain } from 'domain/model/domain.model';
 import { DomainFactory } from 'adapter/factory/domain.factory';
@@ -35,7 +35,7 @@ export class DomainResolver {
 
   @Mutation(() => DomainEntity, { nullable: true })
   async updateDomain(
-    @Args('updateDomainData') data: UpdateDomainDTO, // Argument Input Type pour les données de mise à jour
+    @Args('updateDomainData') data: GqlUpdateDomainDTO, // Argument Input Type pour les données de mise à jour
   ): Promise<DomainEntity | undefined> {
     return this.domainService.edit(data);
   }

--- a/src/domain/domain.service.ts
+++ b/src/domain/domain.service.ts
@@ -67,7 +67,7 @@ export class DomainService implements IDomainService {
   async fetchAll(): Promise<IDomain[]> {
     try {
       return await this.dbRepository.domains.find({
-        order: { updatedAt: 'DESC' },
+        order: { createdAt: 'DESC' },
       });
     } catch (error) {
       this.logger.error(error, 'ERROR::DomainService.fetchAll');

--- a/src/dossier-step/dossier-step.controller.ts
+++ b/src/dossier-step/dossier-step.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Post, Body, Param, Patch, Delete, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { StaffGuard } from 'adapter/guard/auth.guard';
-import { CreateDossierStepDTO, UpdateDossierStepDTO } from './dossier-step.input.dto';
+import { CreateDossierStepDTO, GqlUpdateDossierStepDTO, UpdateDossierStepDTO } from './dossier-step.input.dto';
 import { IDossierStepService } from './dossier-step.service.interface';
 
 @UseGuards(StaffGuard)
@@ -32,7 +32,7 @@ export class DossierStepController {
     return this.dossierStepService.fetchAll();
   }
 
-  @Patch(':id')
+  @Patch()
   @ApiOperation({ summary: 'Modifier un dossier-step' })
   @ApiResponse({ status: 200, description: 'DossierStep modifié.' })
   async update(@Body() dto: UpdateDossierStepDTO) {

--- a/src/dossier-step/dossier-step.input.dto.ts
+++ b/src/dossier-step/dossier-step.input.dto.ts
@@ -1,5 +1,5 @@
-import { InputType, Field, ID, PartialType } from '@nestjs/graphql';
-import { ApiProperty } from '@nestjs/swagger';
+import { InputType, Field, ID, PartialType as GqlPartialType } from '@nestjs/graphql';
+import { ApiProperty, PartialType } from '@nestjs/swagger';
 import { IsDateString, IsEnum, IsOptional, IsString, IsUUID } from 'class-validator';
 import { ICreateDossierStepDTO, IUpdateDossierStepDTO } from './dossier-step.service.interface';
 import { StepStatusEnum } from 'app/enum';
@@ -37,8 +37,14 @@ export class CreateDossierStepDTO implements ICreateDossierStepDTO {
   stepId: string;
 }
 
-@InputType()
 export class UpdateDossierStepDTO extends PartialType(CreateDossierStepDTO) implements IUpdateDossierStepDTO {
+  @ApiProperty()
+  @Field(() => ID)
+  @IsUUID()
+  id: string;
+}
+@InputType()
+export class GqlUpdateDossierStepDTO extends GqlPartialType(CreateDossierStepDTO) implements IUpdateDossierStepDTO {
   @ApiProperty()
   @Field(() => ID)
   @IsUUID()

--- a/src/dossier-step/dossier-step.resolver.ts
+++ b/src/dossier-step/dossier-step.resolver.ts
@@ -2,7 +2,7 @@ import { UseGuards } from '@nestjs/common';
 import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { DossierStep } from 'domain/model/dossier-step.model';
-import { CreateDossierStepDTO, UpdateDossierStepDTO } from './dossier-step.input.dto';
+import { CreateDossierStepDTO, GqlUpdateDossierStepDTO } from './dossier-step.input.dto';
 import { GqlAuthGuard } from 'adapter/guard/auth.guard';
 import { IDossierStepService } from './dossier-step.service.interface';
 import { DossierStepEntity } from 'framework/schema/dossier-step.entity';
@@ -30,7 +30,7 @@ export class DossierStepResolver {
   }
 
   @Mutation(() => DossierStepEntity)
-  async updateDossierStep(@Args('data') data: UpdateDossierStepDTO): Promise<DossierStep> {
+  async updateDossierStep(@Args('data') data: GqlUpdateDossierStepDTO): Promise<DossierStep> {
     return this.dossierStepService.edit(data);
   }
 

--- a/src/dossier-step/dossier-step.service.ts
+++ b/src/dossier-step/dossier-step.service.ts
@@ -57,7 +57,7 @@ export class DossierStepService implements IDossierStepService {
 
   async fetchAll(): Promise<DossierStep[]> {
     try {
-        return this.dbRepository.dossierSteps.find();
+        return this.dbRepository.dossierSteps.find({order: {createdAt: 'DESC'}});
     } catch (error) {
         this.logger.error(error, 'ERROR::DossierStepService.fetchAll');
         throw error;

--- a/src/dossier/dossier.controller.ts
+++ b/src/dossier/dossier.controller.ts
@@ -4,7 +4,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
 import { IDossierService } from './dossier.service.interface';
 import { StaffGuard } from 'adapter/guard/auth.guard';
-import { CreateDossierDTO, UpdateDossierDTO } from './dossier.input.dto';
+import { CreateDossierDTO, GqlUpdateDossierDTO, UpdateDossierDTO } from './dossier.input.dto';
 import { DossierClientFilterDTO } from './dossier-client-filter.input';
 import { BaseConfig } from 'config/base.config';
 import { DossierFactory } from 'adapter/factory/dossier.factory';

--- a/src/dossier/dossier.input.dto.ts
+++ b/src/dossier/dossier.input.dto.ts
@@ -1,5 +1,5 @@
-import { InputType, Field, ID, PartialType } from '@nestjs/graphql';
-import { ApiProperty } from '@nestjs/swagger';
+import { InputType, Field, ID, PartialType as GqlPartialType } from '@nestjs/graphql';
+import { ApiProperty, PartialType } from '@nestjs/swagger';
 // import { GraphQLUpload, FileUpload } from 'graphql-upload';
 import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
 import { ICreateDossierDTO, IUpdateDossierDTO } from './dossier.service.interface';
@@ -30,8 +30,19 @@ export class CreateDossierDTO implements ICreateDossierDTO {
   domainId: string;
 }
 
-@InputType()
 export class UpdateDossierDTO extends PartialType(CreateDossierDTO) implements IUpdateDossierDTO {
+  @ApiProperty()
+  @Field(() => ID)
+  @IsUUID()
+  id: string;
+
+  @ApiProperty({ required: false })
+  @Field({ nullable: true })
+  @IsOptional()
+  closedAt?: Date;
+}
+@InputType()
+export class GqlUpdateDossierDTO extends GqlPartialType(CreateDossierDTO) implements IUpdateDossierDTO {
   @ApiProperty()
   @Field(() => ID)
   @IsUUID()

--- a/src/dossier/dossier.resolver.ts
+++ b/src/dossier/dossier.resolver.ts
@@ -2,7 +2,7 @@ import { UseGuards } from '@nestjs/common';
 import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { Dossier } from 'domain/model/dossier.model';
-import { CreateDossierDTO, UpdateDossierDTO } from './dossier.input.dto';
+import { CreateDossierDTO, GqlUpdateDossierDTO } from './dossier.input.dto';
 import { GqlAuthGuard } from 'adapter/guard/auth.guard';
 import { IDossierService } from './dossier.service.interface';
 import { DossierEntity } from 'framework/schema/dossier.entity';
@@ -31,7 +31,7 @@ export class DossierResolver {
   }
 
   @Mutation(() => DossierEntity)
-  async updateDossier(@Args('data') data: UpdateDossierDTO): Promise<Dossier> {
+  async updateDossier(@Args('data') data: GqlUpdateDossierDTO): Promise<Dossier> {
     return this.dossierService.edit(data);
   }
 

--- a/src/dossier/dossier.service.ts
+++ b/src/dossier/dossier.service.ts
@@ -54,7 +54,7 @@ export class DossierService implements IDossierService {
 
   async fetchAll(): Promise<Dossier[]> {
     try {
-      return await this.dbRepository.dossiers.find();
+      return await this.dbRepository.dossiers.find({order: {createdAt: 'DESC'}});
     } catch (error) {
       this.logger.error(error, 'ERROR::DossierService.fetchAll');
       throw error;

--- a/src/step/step.controller.ts
+++ b/src/step/step.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Post, Body, Param, Patch, Delete, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { StaffGuard } from 'adapter/guard/auth.guard';
-import { CreateStepDTO, UpdateStepDTO } from './step.input.dto';
+import { CreateStepDTO, GqlUpdateStepDTO, UpdateStepDTO } from './step.input.dto';
 import { IStepService } from './step.service.interface';
 
 @UseGuards(StaffGuard)
@@ -32,7 +32,7 @@ export class StepController {
     return this.stepService.fetchAll();
   }
 
-  @Patch(':id')
+  @Patch()
   @ApiOperation({ summary: 'Modifier une étape' })
   @ApiResponse({ status: 200, description: 'Étape modifiée.' })
   async update(@Body() dto: UpdateStepDTO) {

--- a/src/step/step.input.dto.ts
+++ b/src/step/step.input.dto.ts
@@ -1,5 +1,5 @@
-import { InputType, Field, Int, ID, PartialType } from '@nestjs/graphql';
-import { ApiProperty  } from '@nestjs/swagger';
+import { InputType, Field, ID, Int, PartialType as GqlPartialType } from '@nestjs/graphql';
+import { ApiProperty, PartialType } from '@nestjs/swagger';
 import { IsNotEmpty, IsOptional, IsString, IsUUID, IsNumber, Min } from 'class-validator';
 import { ICreateStepDTO } from './step.service.interface';
 
@@ -34,8 +34,14 @@ export class CreateStepDTO implements ICreateStepDTO {
   domainId: string;
 }
 
-@InputType()
 export class UpdateStepDTO extends PartialType(CreateStepDTO) {
+  @ApiProperty({ description: 'ID du step' })
+  @Field(() => ID)
+  @IsUUID()
+  id: string;
+}
+@InputType()
+export class GqlUpdateStepDTO extends GqlPartialType(CreateStepDTO) {
   @ApiProperty({ description: 'ID du step' })
   @Field(() => ID)
   @IsUUID()

--- a/src/step/step.resolver.ts
+++ b/src/step/step.resolver.ts
@@ -1,5 +1,5 @@
 import { Resolver, Query, Mutation, Args } from '@nestjs/graphql';
-import { CreateStepDTO, UpdateStepDTO } from './step.input.dto';
+import { CreateStepDTO, GqlUpdateStepDTO } from './step.input.dto';
 import { Step } from 'domain/model/step.model';
 import { StepEntity } from 'framework/schema/step.entity';
 import { IStepService } from './step.service.interface';
@@ -32,7 +32,7 @@ export class StepResolver {
   @Mutation(() => StepEntity)
   async updateStep(
     @Args('id') id: string,
-    @Args('input') data: UpdateStepDTO,
+    @Args('input') data: GqlUpdateStepDTO,
   ): Promise<Step> {
     return this.stepService.edit(data);
   }

--- a/src/step/step.service.ts
+++ b/src/step/step.service.ts
@@ -41,6 +41,7 @@ export class StepService implements IStepService {
     try {
       return await this.dbRepository.steps.find({
         relations: { domain: true },
+        order: {createdAt: 'DESC'}
       });
     } catch (error) {
       this.logger.error(error, 'ERROR::StepService.fetchAll');

--- a/src/task/task.controller.ts
+++ b/src/task/task.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Post, Body, Param, Patch, Delete, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { StaffGuard } from 'adapter/guard/auth.guard';
-import { CreateTaskDTO, UpdateTaskDTO } from './task.input.dto';
+import { CreateTaskDTO, GqlUpdateTaskDTO, UpdateTaskDTO } from './task.input.dto';
 import { ITaskService } from './task.service.interface';
 
 @UseGuards(StaffGuard)
@@ -32,7 +32,7 @@ export class TaskController {
     return this.taskService.fetchAll();
   }
 
-  @Patch(':id')
+  @Patch()
   @ApiOperation({ summary: 'Modifier une tâche' })
   @ApiResponse({ status: 200, description: 'Tâche modifiée.' })
   async update(@Body() dto: UpdateTaskDTO) {

--- a/src/task/task.input.dto.ts
+++ b/src/task/task.input.dto.ts
@@ -1,5 +1,5 @@
-import { InputType, Field, ID, PartialType } from '@nestjs/graphql';
-import { ApiProperty } from '@nestjs/swagger';
+import { InputType, Field, ID, PartialType as GqlPartialType } from '@nestjs/graphql';
+import { ApiProperty, PartialType } from '@nestjs/swagger';
 import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
 import { ICreateTaskDTO, IUpdateTaskDTO } from './task.service.interface';
 
@@ -23,8 +23,14 @@ export class CreateTaskDTO implements ICreateTaskDTO {
   stepId: string;
 }
 
-@InputType()
 export class UpdateTaskDTO extends PartialType(CreateTaskDTO) implements IUpdateTaskDTO {
+  @ApiProperty()
+  @Field(() => ID)
+  @IsUUID()
+  id: string;
+}
+@InputType()
+export class GqlUpdateTaskDTO extends GqlPartialType(CreateTaskDTO) implements IUpdateTaskDTO {
   @ApiProperty()
   @Field(() => ID)
   @IsUUID()

--- a/src/task/task.resolver.ts
+++ b/src/task/task.resolver.ts
@@ -2,7 +2,7 @@ import { UseGuards } from '@nestjs/common';
 import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { ITask } from 'domain/model/task.model';
-import { CreateTaskDTO, UpdateTaskDTO } from './task.input.dto';
+import { CreateTaskDTO, GqlUpdateTaskDTO } from './task.input.dto';
 import { GqlAuthGuard } from 'adapter/guard/auth.guard';
 import { ITaskService } from './task.service.interface';
 import { TaskEntity } from 'framework/schema/task.entity';
@@ -30,7 +30,7 @@ export class TaskResolver {
   }
 
   @Mutation(() => TaskEntity)
-  async updateTask(@Args('data') data: UpdateTaskDTO): Promise<ITask> {
+  async updateTask(@Args('data') data: GqlUpdateTaskDTO): Promise<ITask> {
     return this.taskService.edit(data);
   }
 

--- a/src/task/task.service.ts
+++ b/src/task/task.service.ts
@@ -32,7 +32,7 @@ export class TaskService implements ITaskService {
 
   async fetchAll(): Promise<ITask[]> {
     try {
-      return await this.dbRepository.tasks.find();
+      return await this.dbRepository.tasks.find({order: {createdAt: 'DESC'}});
     } catch (error) {
       this.logger.error(error, 'ERROR::TaskService.fetchAll');
       throw error;


### PR DESCRIPTION
Refactor factories and services to include GqlUpdate DTOs and improve data handling

- Added GqlUpdate DTOs for Affectation, Comment, Domain, Dossier, Step, and Task to enhance GraphQL integration.
- Updated factory methods to handle undefined inputs gracefully across Affectation, Comment, DossierStep, Dossier, Step, and Task factories.
- Modified AffectationService to support batch creation of affectations and improved error handling.
- Enhanced fetch methods in services to return results in descending order based on creation date.
- Updated controller and resolver methods to utilize new GqlUpdate DTOs for better type safety and clarity.